### PR TITLE
fix bug

### DIFF
--- a/resnet18.py
+++ b/resnet18.py
@@ -76,7 +76,7 @@ class ResNet(nn.Module):
         downsample = None
         if stride != 1 or self.inplanes != planes:
             downsample = nn.Sequential(
-                conv1x1(self.inplanes, planes, stride=stride, bias=False),
+                conv1x1(self.inplanes, planes, stride=stride),
                 nn.BatchNorm2d(planes * block.expansion),
             )
 


### PR DESCRIPTION
`conv1x1` function has no keyword argument 'bias'